### PR TITLE
fix(lootbox): consume exactly one key per lootbox open

### DIFF
--- a/apps/api/repository/lootbox_repository.py
+++ b/apps/api/repository/lootbox_repository.py
@@ -297,15 +297,14 @@ class LootboxRepository(BaseRepository):
         _conn = self._get_connection(conn)
 
         query = """
-                DELETE
-                FROM lootbox.user_keys
-                WHERE earned_at = (
-                    SELECT min(earned_at)
+                DELETE FROM lootbox.user_keys
+                WHERE ctid = (
+                    SELECT ctid
                     FROM lootbox.user_keys
                     WHERE user_id = $1::bigint AND key_type = $2::text
-                )
-                  AND user_id = $1::bigint
-                  AND key_type = $2::text \
+                    ORDER BY earned_at ASC
+                    LIMIT 1
+                ) \
                 """
         result = await _conn.execute(query, user_id, key_type)
         return result != "DELETE 0"

--- a/apps/api/tests/integration/test_lootbox_integration.py
+++ b/apps/api/tests/integration/test_lootbox_integration.py
@@ -167,6 +167,40 @@ class TestDrawRandomRewards:
         assert isinstance(data, list)
         assert len(data) == 3
 
+    async def test_draw_consumes_exactly_one_key_when_timestamps_match(
+        self, test_client, create_test_user, asyncpg_conn
+    ):
+        """Drawing rewards consumes exactly one key even when multiple keys share the same earned_at timestamp.
+
+        Reproduces a bug where bulk-purchased keys (inserted in a single transaction)
+        all got the same earned_at due to PostgreSQL's now() returning transaction start
+        time, causing DELETE to remove all of them at once.
+        """
+        user_id = await create_test_user()
+
+        # Insert 3 keys in a single transaction so they share the same earned_at
+        async with asyncpg_conn.transaction():
+            for _ in range(3):
+                await asyncpg_conn.execute(
+                    "INSERT INTO lootbox.user_keys (user_id, key_type) VALUES ($1, $2)",
+                    user_id,
+                    "Classic",
+                )
+
+        # Verify user starts with 3 keys
+        keys_response = await test_client.get(f"/api/v3/lootbox/users/{user_id}/keys")
+        classic = [k for k in keys_response.json() if k["key_type"] == "Classic"]
+        assert classic[0]["amount"] == 3
+
+        # Draw rewards (consumes 1 key)
+        draw_response = await test_client.get(f"/api/v3/lootbox/users/{user_id}/keys/Classic")
+        assert draw_response.status_code == 200
+
+        # Must have exactly 2 keys remaining, not 0
+        keys_after = await test_client.get(f"/api/v3/lootbox/users/{user_id}/keys")
+        classic_after = [k for k in keys_after.json() if k["key_type"] == "Classic"]
+        assert classic_after[0]["amount"] == 2
+
 
 class TestGrantRewardToUser:
     """POST /api/v3/lootbox/users/{user_id}/{key_type}/{reward_type}/{reward_name}


### PR DESCRIPTION
## Summary

- **Root cause:** `delete_oldest_user_key` used `DELETE WHERE earned_at = min(earned_at)`, which deleted ALL keys sharing the same timestamp — not just one. Since `purchase_keys` inserts all keys in a single transaction and PostgreSQL's `now()` returns the transaction start time, every key in a bulk purchase got an identical `earned_at`. Opening one lootbox consumed the entire batch.
- **Fix:** Switch to a `ctid`-based DELETE with `LIMIT 1` so exactly one row is removed regardless of timestamp collisions.
- **Regression test:** Added integration test that inserts 3 keys in a single transaction (same `earned_at`), draws once, and asserts exactly 1 key was consumed.

## Test plan

- [x] New integration test `test_draw_consumes_exactly_one_key_when_timestamps_match` passes
- [x] All 40 existing lootbox integration tests pass
- [x] All 20 lootbox unit tests pass
- [x] Lint clean (`ruff` + `basedpyright`)