### PR TITLE
fix(maps): allow changing a map's code while it has a linked code

### DIFF
--- a/apps/api/migrations/0026_fix_linked_code_rename.sql
+++ b/apps/api/migrations/0026_fix_linked_code_rename.sql
@@ -1,0 +1,79 @@
+-- Fix: allow changing a map's code while it has a linked_code.
+--
+-- The trigger trg_sync_linked_code fires BEFORE UPDATE OF linked_code, code.
+-- Its body only handles link/unlink semantics (changes to linked_code), but it
+-- also ran for plain `code` renames. On a rename, `linked_code` is unchanged and
+-- still non-null, so the function fell through to its "create link" branch and
+-- read the partner's back-pointer -- which still referenced the OLD code. The
+-- guard `target_current <> new.code` then raised
+--   "Code X is already linked to Y, cannot also link to Z"
+-- aborting the rename before the FK ON UPDATE CASCADE could fix the partner.
+--
+-- Fix: early-return for a pure code rename (an UPDATE where linked_code is
+-- unchanged). In that case the FK ON UPDATE CASCADE on core.maps.linked_code
+-- already keeps the partner's back-pointer in sync, so the link-sync logic must
+-- not run. Link/unlink behaviour (changes to linked_code) and INSERTs are
+-- unchanged.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION core.sync_linked_code() RETURNS trigger
+    LANGUAGE plpgsql AS
+$$
+DECLARE
+    target_current text;
+BEGIN
+    -- Avoid infinite ping-pong when we update the counterpart.
+    IF pg_trigger_depth() > 1 THEN RETURN new; END IF;
+
+    -- Pure code rename: linked_code is unchanged on this UPDATE. The FK
+    -- ON UPDATE CASCADE already updates the partner's linked_code, so the
+    -- link-sync logic below must not run (it would misread the partner's
+    -- pre-cascade back-pointer and wrongly reject the rename).
+    IF TG_OP = 'UPDATE' AND new.linked_code IS NOT DISTINCT FROM old.linked_code THEN
+        RETURN new;
+    END IF;
+
+    -- If unlinking (linked_code becomes NULL), clear the counterpart if it points back
+    IF new.linked_code IS NULL THEN
+        IF old.linked_code IS NOT NULL THEN
+            UPDATE core.maps
+            SET linked_code = NULL
+            WHERE code = old.linked_code AND linked_code = old.code; -- only clear if it points back to us
+        END IF;
+        RETURN new;
+    END IF;
+
+    -- At this point NEW.linked_code is NOT NULL
+    IF new.linked_code = new.code THEN RAISE EXCEPTION 'linked_code cannot equal code (%).', new.code; END IF;
+
+    -- Ensure target exists
+    PERFORM 1
+    FROM core.maps
+    WHERE code = new.linked_code;
+    IF NOT found THEN RAISE EXCEPTION 'linked_code % does not reference an existing code.', new.linked_code; END IF;
+
+    -- Check the target's current link
+    SELECT linked_code
+    INTO target_current
+    FROM core.maps
+    WHERE code = new.linked_code FOR UPDATE;
+    -- serialize against concurrent writers on the target
+
+    -- If target already linked to someone else (not us), forbid
+    IF target_current IS NOT NULL AND target_current <> new.code THEN
+        RAISE EXCEPTION 'Code % is already linked to %, cannot also link to %.', new.linked_code, target_current, new.code;
+    END IF;
+
+    -- If target not linked yet, link it back to us
+    IF target_current IS NULL THEN
+        UPDATE core.maps
+        SET linked_code = new.code
+        WHERE code = new.linked_code AND linked_code IS NULL; -- idempotent
+    END IF;
+
+    RETURN new;
+END
+$$;
+
+COMMIT;

--- a/apps/api/tests/repository/maps/test_maps_repository_advanced_operations.py
+++ b/apps/api/tests/repository/maps/test_maps_repository_advanced_operations.py
@@ -418,6 +418,59 @@ class TestUnlinkMapCodes:
         assert linked1 is None
 
 
+class TestUpdateLinkedMapCode:
+    """Regression: renaming the code of a map that has a linked_code.
+
+    See debug session map-linked-code-cannot-change: the BEFORE trigger
+    trg_sync_linked_code previously rejected a plain ``code`` rename on a
+    linked map with "Code X is already linked to Y, cannot also link to Z".
+    The FK ON UPDATE CASCADE should keep the partner's back-pointer in sync.
+    """
+
+    @pytest.mark.asyncio
+    async def test_rename_linked_map_code_succeeds(
+        self,
+        maps_repo: MapsRepository,
+        db_pool: asyncpg.Pool,
+        used_codes: set[str],
+    ) -> None:
+        """Changing a linked map's code must succeed and cascade to the partner."""
+        code1 = f"R1{uuid4().hex[:4].upper()}"
+        code2 = f"R2{uuid4().hex[:4].upper()}"
+        new_code1 = f"R3{uuid4().hex[:4].upper()}"
+        used_codes.update([code1, code2, new_code1])
+
+        await create_test_map(db_pool, code1)
+        await create_test_map(db_pool, code2)
+
+        # Establish a bidirectional link.
+        await maps_repo.link_map_codes(code1, code2)
+
+        # Rename code1 -> new_code1 (the operation that previously failed).
+        await maps_repo.update_core_map(code1, {"code": new_code1})
+
+        async with db_pool.acquire() as conn:
+            # The renamed map exists under its new code and keeps its link.
+            linked_new = await conn.fetchval(
+                "SELECT linked_code FROM core.maps WHERE code = $1",
+                new_code1,
+            )
+            # The old code no longer exists.
+            old_exists = await conn.fetchval(
+                "SELECT 1 FROM core.maps WHERE code = $1",
+                code1,
+            )
+            # The partner's back-pointer followed the rename via FK cascade.
+            partner_link = await conn.fetchval(
+                "SELECT linked_code FROM core.maps WHERE code = $1",
+                code2,
+            )
+
+        assert old_exists is None
+        assert linked_new == code2
+        assert partner_link == new_code1
+
+
 # ==============================================================================
 # INTEGRATION TESTS
 # ==============================================================================


### PR DESCRIPTION
## Problem

When a map already has a **linked code** (the unofficial/Chinese-server variant paired to an official/global map code), changing that map's `code` to a new one silently failed — the rename was rejected at the database level.

Reported via the bot slash command, which routes through the maps API (`update_map` → `update_core_map`).

## Root Cause

The `core.sync_linked_code()` trigger (introduced in `0001_init.sql`) fires `BEFORE UPDATE OF linked_code, code`. Its body handles link/unlink semantics, but it **also ran on a plain `code` rename**. On a rename, `linked_code` is unchanged and still non-null, so the function fell through to its "create link" branch and read the partner's back-pointer — which still referenced the **old** code. The guard then raised:

```
Code X is already linked to Y, cannot also link to Z
```

aborting the rename before the FK `ON UPDATE CASCADE` could update the partner.

This bug has existed since `0001_init.sql` and is **independent of the release-codes feature** (migration 0019) — it only surfaces when a map has a `linked_code` and its `code` is renamed.

## Fix

`0020_fix_linked_code_rename.sql` rewrites the trigger function to **early-return on a pure code rename** (`TG_OP = 'UPDATE' AND new.linked_code IS NOT DISTINCT FROM old.linked_code`). In that case the FK `ON UPDATE CASCADE` on `core.maps.linked_code` already keeps the partner's back-pointer in sync, so the link-sync logic must not run. Link/unlink behaviour and INSERTs are unchanged.

## Testing

- Added regression test `TestUpdateLinkedMapCode::test_rename_linked_map_code_succeeds` — confirmed **RED before** the fix, **GREEN after**.
- Full maps + release-code suites pass: **137 passed** across `tests/repository/maps/`, `tests/integration/test_maps_integration.py`, `tests/integration/test_release_code_integration.py`, `tests/repository/test_release_code_repository.py`.