### PR TITLE
feat(completions): add DELETE /completions/suspicious route

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,8 +3,8 @@ gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: — Phases
 status: unknown
-last_updated: "2026-06-01T22:40:10.726Z"
-last_activity: 2026-06-01
+last_updated: "2026-06-08T22:16:27.539Z"
+last_activity: 2026-06-08
 progress:
   total_phases: 2
   completed_phases: 2
@@ -15,7 +15,7 @@ progress:
 
 # Tournament System — State
 
-Last activity: 2026-06-07 - Completed quick task 260607-oqy: add tournament announcement role ping (config + announcements + role-react toggle)
+Last activity: 2026-06-08 - Completed quick task 260608-ntz: Add an API route to remove a suspicious flag
 
 ## Current Status
 
@@ -56,6 +56,7 @@ Controller → Service → Repository pattern:
 | 260603-mla | Add boundary-streak cohorts to `scripts/seed_tournament_fake_data.sql`: 9 disjoint non-regular users sliced from one random draw, pinned to consecutive trailing edition runs of 2/3/5 (excluded from filler selection) so the unchanged gaps-and-islands derivation lands them on current_streak 2/3/5 — exercising the `streak_xp` thresholds (3 and 5) that the old bimodal {1, 26} distribution never hit. Debug-seed only — script left untracked per its DO-NOT-COMMIT banner; only planning docs committed. | 2026-06-03 | 41ffd64 | [260603-mla-add-boundary-streak-cohorts-to-tournamen](./quick/260603-mla-add-boundary-streak-cohorts-to-tournamen/) |
 | 260605-gjy | Fix start-only rollover announcement: the `elif event.started` branch in `_on_edition_rollover` now leads with `# 🏆 New Tournament!` instead of `Tournament Ended!` — the start-only case (out-of-hiatus or never-started, `has_ended` False) had nothing end, so it no longer announces a non-existent prior tournament. Normal (results+started) and into-hiatus (results-only) branches keep their `Tournament Ended!` framing unchanged. Locked with assertions in the three existing rollover handler tests. | 2026-06-05 | 07f4745 | [260605-gjy-start-only-rollover-title](./quick/260605-gjy-start-only-rollover-title/) |
 | 260607-oqy | Add a pingable tournament announcement role: new `mentionable.tournament_announcements` config field (struct + dev/prod TOML, `0` sentinel placeholder for maintainer-supplied IDs); both public announcement cards (`_on_edition_rollover`, `_on_edition_results`) prepend a `<@&id>` ping via shared `_tournament_ping()` helper with role allow-listed in `AllowedMentions`; self-assignable "Tournament Announcements" 🏆 toggle added to the `#role-react` view (`ServerRoleSelectView`), sourced from the same config field. Every touch point guards the `0` sentinel (no broken `<@&0>`, no crash-on-click button). | 2026-06-07 | 43e0904 | [260607-oqy-add-a-role-ping-to-tournament-announceme](./quick/260607-oqy-add-a-role-ping-to-tournament-announceme/) |
+| 260608-ntz | Add an API route to remove a suspicious flag: symmetric `DELETE /completions/suspicious` mirroring the add route across all four layers (SDK `SuspiciousCompletionDeleteRequest`, repo `delete_suspicious_flag_by_message` reusing the insert's message/verification CTE, service `remove_suspicious_flags`, controller handler with the same 400 identifier guard + `status_code=200`) plus a bot `remove_suspicious_flags` client. Removing a non-existent flag returns 200 count 0. Fixes #50. | 2026-06-08 | 66c0b11 | [260608-ntz-add-an-api-route-to-remove-a-suspicious-](./quick/260608-ntz-add-an-api-route-to-remove-a-suspicious-/) |
 
 ## Blockers/Concerns
 

--- a/.planning/quick/260608-ntz-add-an-api-route-to-remove-a-suspicious-/260608-ntz-PLAN.md
+++ b/.planning/quick/260608-ntz-add-an-api-route-to-remove-a-suspicious-/260608-ntz-PLAN.md
@@ -1,0 +1,173 @@
+---
+phase: quick
+plan: 260608-ntz
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - libs/sdk/src/genjishimada_sdk/completions.py
+  - apps/api/repository/completions_repository.py
+  - apps/api/services/completions_service.py
+  - apps/api/routes/v3/completions.py
+  - apps/bot/extensions/api_service.py
+autonomous: true
+requirements: [QUICK-REMOVE-SUSPICIOUS-FLAG]
+must_haves:
+  truths:
+    - "A DELETE /completions/suspicious request removes the suspicious flag for the completion identified by message_id or verification_id"
+    - "Requesting removal for a completion that has no flag returns a clean success (no flag deleted) rather than a 500"
+    - "The removal route mirrors the existing POST /suspicious route exactly (same controller, same identifier model, same exception translation style)"
+  artifacts:
+    - path: "libs/sdk/src/genjishimada_sdk/completions.py"
+      provides: "SuspiciousCompletionDeleteRequest msgspec struct"
+      contains: "class SuspiciousCompletionDeleteRequest"
+    - path: "apps/api/repository/completions_repository.py"
+      provides: "delete_suspicious_flag_by_message method (delete by message_id/verification_id)"
+      contains: "delete_suspicious_flag_by_message"
+    - path: "apps/api/services/completions_service.py"
+      provides: "remove_suspicious_flags service method"
+      contains: "remove_suspicious_flags"
+    - path: "apps/api/routes/v3/completions.py"
+      provides: "DELETE /suspicious route handler"
+      contains: "delete_suspicious_flags"
+  key_links:
+    - from: "apps/api/routes/v3/completions.py"
+      to: "CompletionsService.remove_suspicious_flags"
+      via: "svc.remove_suspicious_flags(data)"
+      pattern: "svc\\.remove_suspicious_flags"
+    - from: "apps/api/services/completions_service.py"
+      to: "CompletionsRepository.delete_suspicious_flag_by_message"
+      via: "repo method call"
+      pattern: "delete_suspicious_flag_by_message"
+---
+
+<objective>
+Add an API route to REMOVE a suspicious flag from a completion, mirroring the existing add route (`POST /completions/suspicious`) exactly.
+
+Purpose: The tournament verification system (commit 5bf0d7a) added the ability to flag a completion as suspicious via `POST /completions/suspicious` using `message_id`/`verification_id`. There is no standalone REST route to remove a flag by the same identifier model — the only removal path today is the combined `CompletionModerateRequest` (`unmark_suspicious`) flow. This adds a symmetric `DELETE /completions/suspicious` route.
+
+Output: New SDK request struct, repository delete-by-message method, service method, DELETE route handler, and bot API client method.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@./CLAUDE.md
+
+<interfaces>
+<!-- Existing ADD-route conventions the removal route MUST mirror. Use these directly. -->
+
+The existing ADD route resolves a completion from message_id OR verification_id (NOT completion_id).
+SuspiciousCompletionCreateRequest (libs/sdk/src/genjishimada_sdk/completions.py:361):
+```python
+class SuspiciousCompletionCreateRequest(Struct):
+    context: str
+    flag_type: SuspiciousFlag
+    flagged_by: int
+    message_id: int | None = None
+    verification_id: int | None = None
+```
+
+Repository insert (apps/api/repository/completions_repository.py:1736) resolves completion via CTE:
+```sql
+WITH message_to_completion_id AS (
+  SELECT id FROM core.completions
+  WHERE ($1::bigint IS NOT NULL AND message_id = $1::bigint)
+     OR ($1::bigint IS NULL     AND verification_id = $2::bigint)
+  LIMIT 1
+)
+```
+
+Existing delete-by-completion-id method (apps/api/repository/completions_repository.py:1996) — used only by the moderate flow, returns deleted count:
+```python
+async def delete_suspicious_flag(self, completion_id: int, *, conn=None) -> int
+```
+
+Controller route (apps/api/routes/v3/completions.py:229) — note: NO explicit required_scopes opt (relies on global guard):
+```python
+@post(path="/suspicious", summary="Set Suspicious Flag", ...)
+async def set_suspicious_flags(self, svc, data: SuspiciousCompletionCreateRequest) -> None:
+    if not data.message_id and not data.verification_id:
+        raise CustomHTTPException(detail="One of message_id or verification_id must be used.", status_code=HTTP_400_BAD_REQUEST)
+    return await svc.set_suspicious_flags(data)
+```
+
+Service (apps/api/services/completions_service.py:1208) translates repo exceptions to domain exceptions (UniqueConstraintViolationError -> DuplicateFlagError, ForeignKeyViolationError -> CompletionNotFoundError).
+
+Bot client (apps/bot/extensions/api_service.py:1307) uses `Route("POST", "/completions/suspicious")` and `self._request(...)`.
+
+`delete` is NOT yet imported in the controller — it imports `get, patch, post, put` from litestar (line 27).
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add SDK request struct + repository delete-by-message method</name>
+  <files>libs/sdk/src/genjishimada_sdk/completions.py, apps/api/repository/completions_repository.py</files>
+  <action>
+In libs/sdk/src/genjishimada_sdk/completions.py: add a new `SuspiciousCompletionDeleteRequest(Struct)` immediately after `SuspiciousCompletionCreateRequest` (around line 377). Fields: `message_id: int | None = None`, `verification_id: int | None = None`. Add a Google-style docstring describing it as the payload for removing a suspicious flag, identified by either message_id or verification_id. Add `"SuspiciousCompletionDeleteRequest"` to the `__all__` list near the top (alongside the existing `"SuspiciousCompletionCreateRequest"` entry, keeping alphabetical/existing ordering consistent with neighbors).
+
+In apps/api/repository/completions_repository.py: add a new method `delete_suspicious_flag_by_message` placed right after the existing `delete_suspicious_flag` method (around line 2018). Signature mirrors the insert's identifier model:
+`async def delete_suspicious_flag_by_message(self, message_id: int | None, verification_id: int | None, *, conn: Connection | None = None) -> int`.
+Use `_conn = self._get_connection(conn)`. Resolve the completion id with the SAME CTE shape used by `insert_suspicious_flag` (lines 1757-1768) — a `message_to_completion_id` CTE matching message_id OR verification_id — then DELETE from `users.suspicious_flags WHERE completion_id IN (SELECT id FROM message_to_completion_id)`. Use `_conn.execute(...)` and parse the returned status tag (e.g. `result.split()[-1]`) to return the number of rows deleted as `int`, returning 0 when nothing matched. Do NOT add try/except for constraint violations — deletion does not violate unique/FK constraints and missing rows must return 0, not error (per CLAUDE.md "let exceptions propagate" guidance). Add a Google-style docstring (Args + Returns).
+  </action>
+  <verify>
+    <automated>cd /Users/nebula/coding/parkour/genji/genjishimada && just lint-sdk && uv run --package genjishimada-api python -c "import ast,sys; src=open('apps/api/repository/completions_repository.py').read(); ast.parse(src); sys.exit(0 if 'delete_suspicious_flag_by_message' in src else 1)"</automated>
+  </verify>
+  <done>SuspiciousCompletionDeleteRequest exists in SDK and is exported in __all__; delete_suspicious_flag_by_message exists in the repository and parses cleanly; lint-sdk passes.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add service method + DELETE controller route</name>
+  <files>apps/api/services/completions_service.py, apps/api/routes/v3/completions.py</files>
+  <action>
+In apps/api/services/completions_service.py: import `SuspiciousCompletionDeleteRequest` in the existing genjishimada_sdk.completions import block (near line 28-29 where `SuspiciousCompletionCreateRequest`/`SuspiciousCompletionResponse` are imported). Add an `async def remove_suspicious_flags(self, data: SuspiciousCompletionDeleteRequest) -> int` method directly after `set_suspicious_flags` (around line 1226). It calls `await self._completions_repo.delete_suspicious_flag_by_message(message_id=data.message_id, verification_id=data.verification_id)` and returns the deleted count. Google-style docstring (Returns: number of flags removed). No exception translation needed (deletion of a non-existent flag returns 0, matching the moderate flow's `unmark_suspicious` behavior at lines 1406-1411).
+
+In apps/api/routes/v3/completions.py:
+1. Add `delete` to the litestar import on line 27 (`from litestar import Controller, Request, Response, delete, get, patch, post, put`).
+2. Add `SuspiciousCompletionDeleteRequest` to the genjishimada_sdk.completions import block (lines 8-23).
+3. Add a `delete_suspicious_flags` route handler immediately after `set_suspicious_flags` (after line 242). Use `@delete(path="/suspicious", summary="Remove Suspicious Flag", description="Remove an existing suspicious flag from a completion.", status_code=200)` (explicit 200 so a body/return value is allowed; default litestar DELETE is 204 No Content). Handler signature: `async def delete_suspicious_flags(self, svc: CompletionsService, data: SuspiciousCompletionDeleteRequest) -> int:`. Mirror the add route's identifier guard exactly: if `not data.message_id and not data.verification_id`, raise `CustomHTTPException(detail="One of message_id or verification_id must be used.", status_code=HTTP_400_BAD_REQUEST)`. Then `return await svc.remove_suspicious_flags(data)`. Do NOT add `opt={"required_scopes": ...}` — the sibling `set_suspicious_flags` route has none, so the removal route matches it.
+  </action>
+  <verify>
+    <automated>cd /Users/nebula/coding/parkour/genji/genjishimada && just lint-api</automated>
+  </verify>
+  <done>remove_suspicious_flags service method exists; DELETE /suspicious route handler exists with the same identifier guard as the add route and uses status_code 200; lint-api (format + lint + typecheck) passes.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Add bot API client method + integration test</name>
+  <files>apps/bot/extensions/api_service.py, apps/api/tests/integration/test_completions_integration.py</files>
+  <action>
+In apps/bot/extensions/api_service.py: import `SuspiciousCompletionDeleteRequest` in the existing genjishimada_sdk.completions import block (near line 38). Add a `remove_suspicious_flags` method directly after `set_suspicious_flags` (after line 1318), mirroring it: `def remove_suspicious_flags(self, data: SuspiciousCompletionDeleteRequest) -> Response[...]:` using `r = Route("DELETE", "/completions/suspicious")` and `return self._request(r, ...)`. Match the exact `_request` call shape and return-type annotation style used by `set_suspicious_flags` (inspect lines 1307-1318 and reuse the same pattern; pass the encoded `data` the same way the add method does). Google-style docstring.
+
+In apps/api/tests/integration/test_completions_integration.py: add an async test that (1) creates a completion + suspicious flag via the existing fixtures/helpers used by the current suspicious-flag tests in this file (search for the existing `suspicious` test setup to reuse fixtures), (2) issues `DELETE /completions/suspicious` (use the test client used elsewhere in this file) with a `message_id` or `verification_id` JSON body, (3) asserts a 200 response and that the deleted count is 1, and (4) asserts a follow-up GET `/completions/suspicious?user_id=...` no longer returns the flag. Also add a case asserting that deleting when no flag exists returns 200 with count 0. Follow the existing test conventions in this file (test files are exempt from lint, so style is flexible — match neighboring tests).
+  </action>
+  <verify>
+    <automated>cd /Users/nebula/coding/parkour/genji/genjishimada && uv run --package genjishimada-api pytest apps/api/tests/integration/test_completions_integration.py -k suspicious -x -q</automated>
+  </verify>
+  <done>Bot client has remove_suspicious_flags using DELETE /completions/suspicious; integration test for removal passes (both the happy path and the no-flag count-0 case).</done>
+</task>
+
+</tasks>
+
+<verification>
+- `just lint-all` passes (sdk + api + bot formatting, lint, typecheck).
+- `uv run --package genjishimada-api pytest apps/api/tests/integration/test_completions_integration.py -k suspicious -q` passes.
+- Manual: with API running, `curl -X DELETE http://localhost:8000/api/v3/content/.../completions/suspicious` (correct prefix per app config) with `{"message_id": <id>}` returns 200 and removes the flag; the matching GET no longer lists it.
+</verification>
+
+<success_criteria>
+- DELETE /completions/suspicious route exists, mirrors POST /suspicious (same controller, same message_id/verification_id identifier model, same 400 guard, same lack of explicit scopes).
+- Removing a non-existent flag returns 200 with count 0 (no 500, no error) — consistent with the moderate flow's unmark behavior.
+- New SDK struct, repo method, service method, and bot client method all follow Genji's three-layer + msgspec conventions.
+- No RabbitMQ event added (the add route publishes none; removal stays symmetric).
+</success_criteria>
+
+<output>
+Create `.planning/quick/260608-ntz-add-an-api-route-to-remove-a-suspicious-/260608-ntz-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260608-ntz-add-an-api-route-to-remove-a-suspicious-/260608-ntz-SUMMARY.md
+++ b/.planning/quick/260608-ntz-add-an-api-route-to-remove-a-suspicious-/260608-ntz-SUMMARY.md
@@ -1,0 +1,77 @@
+---
+phase: quick
+plan: 260608-ntz
+subsystem: completions
+tags: [api, completions, suspicious-flags, moderation]
+requires:
+  - "POST /completions/suspicious (commit 5bf0d7a)"
+provides:
+  - "DELETE /completions/suspicious route"
+  - "SuspiciousCompletionDeleteRequest SDK struct"
+  - "CompletionsRepository.delete_suspicious_flag_by_message"
+  - "CompletionsService.remove_suspicious_flags"
+  - "APIService.remove_suspicious_flags bot client"
+affects:
+  - libs/sdk/src/genjishimada_sdk/completions.py
+  - apps/api/repository/completions_repository.py
+  - apps/api/services/completions_service.py
+  - apps/api/routes/v3/completions.py
+  - apps/bot/extensions/api_service.py
+  - apps/api/tests/integration/test_completions_integration.py
+tech-stack:
+  added: []
+  patterns: [three-layer-controller-service-repository, msgspec-structs, asyncpg-cte-identifier-resolution]
+key-files:
+  created: []
+  modified:
+    - libs/sdk/src/genjishimada_sdk/completions.py
+    - apps/api/repository/completions_repository.py
+    - apps/api/services/completions_service.py
+    - apps/api/routes/v3/completions.py
+    - apps/bot/extensions/api_service.py
+    - apps/api/tests/integration/test_completions_integration.py
+decisions:
+  - "Mirrored POST /suspicious exactly: same controller, same message_id/verification_id identifier model, same 400 guard, no explicit required_scopes."
+  - "DELETE route uses status_code=200 (not default 204) so the deleted-flag count can be returned in the body."
+  - "Repository delete returns 0 for a non-existent flag (no try/except) — deletion never violates unique/FK constraints, matching the moderate-flow unmark behavior."
+metrics:
+  duration: ~30m
+  completed: 2026-06-08
+---
+
+# Quick Task 260608-ntz: Add API Route to Remove a Suspicious Flag Summary
+
+Adds a symmetric `DELETE /completions/suspicious` route that removes a suspicious flag identified by `message_id`/`verification_id`, mirroring the existing `POST /completions/suspicious` add route across all four layers (SDK struct, repository, service, controller) plus a bot API client method.
+
+## What Was Built
+
+- **SDK** (`libs/sdk/src/genjishimada_sdk/completions.py`): `SuspiciousCompletionDeleteRequest(Struct)` with optional `message_id`/`verification_id`, exported in `__all__`.
+- **Repository** (`apps/api/repository/completions_repository.py`): `delete_suspicious_flag_by_message(message_id, verification_id, *, conn=None) -> int`. Resolves the completion id via the SAME `message_to_completion_id` CTE used by `insert_suspicious_flag`, then `DELETE FROM users.suspicious_flags WHERE completion_id IN (...)`. Parses the asyncpg status tag (`result.split()[-1]`) to return the deleted-row count; returns 0 when nothing matched. No constraint-violation try/except (per CLAUDE.md "let exceptions propagate").
+- **Service** (`apps/api/services/completions_service.py`): `remove_suspicious_flags(data) -> int` delegating to the repo method. No exception translation (delete-of-nonexistent returns 0, consistent with the moderate flow's `unmark_suspicious`).
+- **Controller** (`apps/api/routes/v3/completions.py`): added `delete` to the litestar import, imported the new struct, and added a `delete_suspicious_flags` handler with `@delete(path="/suspicious", status_code=200)` and the identical "one of message_id or verification_id must be used" 400 guard. No explicit `required_scopes` (matches the sibling add route).
+- **Bot client** (`apps/bot/extensions/api_service.py`): `remove_suspicious_flags(data)` using `Route("DELETE", "/completions/suspicious")` and `self._request(r, data=data)`, mirroring `set_suspicious_flags`.
+- **Tests** (`apps/api/tests/integration/test_completions_integration.py`): `TestRemoveSuspiciousFlag` with happy-path removal (asserts 200 + count 1 + flag no longer listed via GET), no-flag case (200 + count 0), and missing-identifier guard (400).
+
+## Verification
+
+- `just lint-all` (sdk + api + bot format/lint/typecheck): all clean, 0 errors.
+- `uv run --package genjishimada-api pytest apps/api/tests/integration/test_completions_integration.py -k suspicious -q`: **6 passed** (3 pre-existing + 3 new).
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Integration test must set `message_id` on the completion row before flagging**
+- **Found during:** Task 3
+- **Issue:** The plan suggested reusing existing fixtures/helpers to create a completion + suspicious flag. In practice, `POST /completions/` creates the completion with `message_id = NULL` (message_id is attached later during verification). Because `POST /completions/suspicious` resolves the completion by `message_id` via `INSERT ... SELECT`, flagging a freshly-submitted completion silently inserts zero rows (the SELECT matches nothing — no FK error), so the GET listed no flag and the removal could not be exercised end-to-end.
+- **Fix:** Each test acquires `asyncpg_pool` and runs `UPDATE core.completions SET message_id=$1 WHERE id=$2` after submission (the same field verification would populate), so the add/remove identifier model resolves correctly. This is the minimal, realistic state needed; it does not change any production code.
+- **Files modified:** apps/api/tests/integration/test_completions_integration.py
+- **Commit:** 66c0b11
+
+## Commits
+
+- `da91d30` feat(quick-260608-ntz): add SuspiciousCompletionDeleteRequest struct and delete-by-message repo method
+- `d48d8f9` feat(quick-260608-ntz): add DELETE /completions/suspicious route and service method
+- `66c0b11` feat(quick-260608-ntz): add bot remove_suspicious_flags client + integration tests
+
+## Self-Check: PASSED

--- a/apps/api/repository/completions_repository.py
+++ b/apps/api/repository/completions_repository.py
@@ -2017,6 +2017,43 @@ class CompletionsRepository(BaseRepository):
 
         return deleted_count
 
+    async def delete_suspicious_flag_by_message(
+        self,
+        message_id: int | None,
+        verification_id: int | None,
+        *,
+        conn: Connection | None = None,
+    ) -> int:
+        """Delete suspicious flag(s) for a completion resolved by message or verification ID.
+
+        Resolves the completion using the same identifier model as
+        ``insert_suspicious_flag`` (message_id OR verification_id), then deletes
+        any matching suspicious flags. Returns 0 when no flag matched.
+
+        Args:
+            message_id: Discord message ID (if completion has been posted).
+            verification_id: Discord verification message ID (if pending).
+            conn: Optional connection for transaction support.
+
+        Returns:
+            Number of flags deleted.
+        """
+        _conn = self._get_connection(conn)
+        query = """
+            WITH message_to_completion_id AS (
+            SELECT id
+            FROM core.completions
+            WHERE
+                ($1::bigint IS NOT NULL AND message_id = $1::bigint) OR
+                ($1::bigint IS NULL     AND verification_id = $2::bigint)
+            LIMIT 1
+            )
+            DELETE FROM users.suspicious_flags
+            WHERE completion_id IN (SELECT id FROM message_to_completion_id);
+        """
+        result = await _conn.execute(query, message_id, verification_id)
+        return int(result.split()[-1])
+
 
 async def provide_completions_repository(state: State) -> CompletionsRepository:
     """Litestar DI provider for CompletionsRepository."""

--- a/apps/api/routes/v3/completions.py
+++ b/apps/api/routes/v3/completions.py
@@ -17,6 +17,7 @@ from genjishimada_sdk.completions import (
     PendingVerificationResponse,
     QualityUpdateRequest,
     SuspiciousCompletionCreateRequest,
+    SuspiciousCompletionDeleteRequest,
     SuspiciousCompletionResponse,
     UpvoteCreateRequest,
     UpvoteSubmissionJobResponse,
@@ -24,7 +25,7 @@ from genjishimada_sdk.completions import (
 from genjishimada_sdk.difficulties import DifficultyTop
 from genjishimada_sdk.internal import JobStatusResponse
 from genjishimada_sdk.maps import OverwatchCode
-from litestar import Controller, Request, Response, get, patch, post, put
+from litestar import Controller, Request, Response, delete, get, patch, post, put
 from litestar.datastructures import State
 from litestar.di import Provide
 from litestar.exceptions import HTTPException
@@ -240,6 +241,24 @@ class CompletionsController(Controller):
                 detail="One of message_id or verification_id must be used.", status_code=HTTP_400_BAD_REQUEST
             )
         return await svc.set_suspicious_flags(data)
+
+    @delete(
+        path="/suspicious",
+        summary="Remove Suspicious Flag",
+        description="Remove an existing suspicious flag from a completion.",
+        status_code=200,
+    )
+    async def delete_suspicious_flags(
+        self,
+        svc: CompletionsService,
+        data: SuspiciousCompletionDeleteRequest,
+    ) -> int:
+        """Remove a suspicious flag from a completion. Returns the number of flags removed."""
+        if not data.message_id and not data.verification_id:
+            raise CustomHTTPException(
+                detail="One of message_id or verification_id must be used.", status_code=HTTP_400_BAD_REQUEST
+            )
+        return await svc.remove_suspicious_flags(data)
 
     @post(
         path="/upvoting",

--- a/apps/api/services/completions_service.py
+++ b/apps/api/services/completions_service.py
@@ -26,6 +26,7 @@ from genjishimada_sdk.completions import (
     OcrResponse,
     PendingVerificationResponse,
     SuspiciousCompletionCreateRequest,
+    SuspiciousCompletionDeleteRequest,
     SuspiciousCompletionResponse,
     UpvoteCreateRequest,
     UpvoteSubmissionJobResponse,
@@ -1224,6 +1225,17 @@ class CompletionsService(BaseService):
             raise DuplicateFlagError(data.verification_id or 0)
         except ForeignKeyViolationError:
             raise CompletionNotFoundError(data.verification_id or 0)
+
+    async def remove_suspicious_flags(self, data: SuspiciousCompletionDeleteRequest) -> int:
+        """Remove a suspicious flag from a completion resolved by message or verification ID.
+
+        Returns:
+            Number of flags removed (0 if no matching flag existed).
+        """
+        return await self._completions_repo.delete_suspicious_flag_by_message(
+            message_id=data.message_id,
+            verification_id=data.verification_id,
+        )
 
     async def get_upvotes_from_message_id(self, message_id: int) -> int:
         """Get the upvotes for a particular completion by message_id."""

--- a/apps/api/tests/integration/test_completions_integration.py
+++ b/apps/api/tests/integration/test_completions_integration.py
@@ -429,6 +429,112 @@ class TestGetSuspiciousFlags:
             assert "created_at" in flag
 
 
+class TestRemoveSuspiciousFlag:
+    """DELETE /api/v3/completions/suspicious"""
+
+    async def test_happy_path_removes_flag(
+        self, test_client, create_test_user, create_test_map, unique_map_code, unique_message_id, asyncpg_pool
+    ):
+        """Deleting a suspicious flag by message_id returns 200 with count 1 and removes the flag."""
+        user_id = await create_test_user()
+        flagger_id = await create_test_user()
+        code = unique_map_code
+        await create_test_map(code=code, checkpoints=10)
+
+        message_id = unique_message_id
+        completion_payload = {
+            "user_id": user_id,
+            "code": code,
+            "time": 45.5,
+            "video": "https://youtube.com/watch?v=test",
+            "screenshot": "https://example.com/screenshot.png",
+            "message_id": message_id,
+        }
+        submit_response = await test_client.post("/api/v3/completions/", json=completion_payload)
+        assert submit_response.status_code == 201
+        completion_id = submit_response.json()["completion_id"]
+
+        # Completions are created pending (message_id NULL); the suspicious-flag identifier
+        # model resolves the completion by message_id, so attach it the way verification does.
+        async with asyncpg_pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE core.completions SET message_id=$1 WHERE id=$2", message_id, completion_id
+            )
+
+        # Flag the completion as suspicious via the existing add route
+        flag_response = await test_client.post(
+            "/api/v3/completions/suspicious",
+            json={
+                "context": "Suspiciously fast run",
+                "flag_type": "Cheating",
+                "flagged_by": flagger_id,
+                "message_id": message_id,
+            },
+        )
+        assert flag_response.status_code in (200, 201)
+
+        # Sanity check: the flag is listed for the flagged user
+        list_before = await test_client.get("/api/v3/completions/suspicious", params={"user_id": user_id})
+        assert list_before.status_code == 200
+        assert any(flag["message_id"] == message_id for flag in list_before.json())
+
+        # Remove the flag
+        delete_response = await test_client.request(
+            "DELETE",
+            "/api/v3/completions/suspicious",
+            json={"message_id": message_id},
+        )
+        assert delete_response.status_code == 200
+        assert delete_response.json() == 1
+
+        # The flag should no longer be listed
+        list_after = await test_client.get("/api/v3/completions/suspicious", params={"user_id": user_id})
+        assert list_after.status_code == 200
+        assert not any(flag["message_id"] == message_id for flag in list_after.json())
+
+    async def test_remove_nonexistent_flag_returns_zero(
+        self, test_client, create_test_user, create_test_map, unique_map_code, unique_message_id, asyncpg_pool
+    ):
+        """Deleting a flag when none exists returns 200 with count 0 (no error)."""
+        user_id = await create_test_user()
+        code = unique_map_code
+        await create_test_map(code=code, checkpoints=10)
+
+        message_id = unique_message_id
+        completion_payload = {
+            "user_id": user_id,
+            "code": code,
+            "time": 45.5,
+            "video": "https://youtube.com/watch?v=test",
+            "screenshot": "https://example.com/screenshot.png",
+            "message_id": message_id,
+        }
+        submit_response = await test_client.post("/api/v3/completions/", json=completion_payload)
+        assert submit_response.status_code == 201
+        completion_id = submit_response.json()["completion_id"]
+        async with asyncpg_pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE core.completions SET message_id=$1 WHERE id=$2", message_id, completion_id
+            )
+
+        delete_response = await test_client.request(
+            "DELETE",
+            "/api/v3/completions/suspicious",
+            json={"message_id": message_id},
+        )
+        assert delete_response.status_code == 200
+        assert delete_response.json() == 0
+
+    async def test_remove_requires_identifier(self, test_client):
+        """Deleting without message_id or verification_id returns 400."""
+        delete_response = await test_client.request(
+            "DELETE",
+            "/api/v3/completions/suspicious",
+            json={},
+        )
+        assert delete_response.status_code == 400
+
+
 class TestEditCompletion:
     """PATCH /api/v3/completions/{record_id}"""
 

--- a/apps/bot/extensions/api_service.py
+++ b/apps/bot/extensions/api_service.py
@@ -36,6 +36,7 @@ from genjishimada_sdk.completions import (
     PendingVerificationResponse,
     QualityUpdateRequest,
     SuspiciousCompletionCreateRequest,
+    SuspiciousCompletionDeleteRequest,
     UpvoteCreateRequest,
     UpvoteSubmissionJobResponse,
 )
@@ -1316,6 +1317,20 @@ class APIService:
             Response[SuspiciousCompletionCreateRequest]: The created suspicious flag record.
         """
         r = Route("POST", "/completions/suspicious")
+        return self._request(r, data=data)
+
+    def remove_suspicious_flags(
+        self, data: SuspiciousCompletionDeleteRequest
+    ) -> Response[SuspiciousCompletionDeleteRequest]:
+        """Remove a suspicious flag from a completion.
+
+        Args:
+            data: Payload identifying the suspicious flag to remove (message_id or verification_id).
+
+        Returns:
+            Response[SuspiciousCompletionDeleteRequest]: The number of flags removed.
+        """
+        r = Route("DELETE", "/completions/suspicious")
         return self._request(r, data=data)
 
     def upvote_submission(self, data: UpvoteCreateRequest) -> Response[UpvoteSubmissionJobResponse]:

--- a/libs/sdk/src/genjishimada_sdk/completions.py
+++ b/libs/sdk/src/genjishimada_sdk/completions.py
@@ -24,6 +24,7 @@ __all__ = (
     "PendingVerificationResponse",
     "QualityUpdateRequest",
     "SuspiciousCompletionCreateRequest",
+    "SuspiciousCompletionDeleteRequest",
     "SuspiciousCompletionResponse",
     "SuspiciousFlag",
     "TimePlayedPerRankResponse",
@@ -372,6 +373,21 @@ class SuspiciousCompletionCreateRequest(Struct):
     context: str
     flag_type: SuspiciousFlag
     flagged_by: int
+    message_id: int | None = None
+    verification_id: int | None = None
+
+
+class SuspiciousCompletionDeleteRequest(Struct):
+    """Request payload for removing a suspicious flag from a completion.
+
+    The completion is identified by either ``message_id`` or ``verification_id``,
+    mirroring the identifier model used when the flag was created.
+
+    Attributes:
+        message_id: Discord message ID associated with the run.
+        verification_id: Verification record ID, if applicable.
+    """
+
     message_id: int | None = None
     verification_id: int | None = None
 


### PR DESCRIPTION
Fixes #50.

## What

Adds a symmetric `DELETE /completions/suspicious` route to remove a suspicious flag from a completion, mirroring the existing `POST /completions/suspicious` add route (introduced by the tournament verification system, `5bf0d7a`) across all layers.

## Changes (three-layer + SDK + bot)

- **SDK** (`libs/sdk/.../completions.py`): new `SuspiciousCompletionDeleteRequest` struct (`message_id` / `verification_id`), exported in `__all__`.
- **Repository** (`completions_repository.py`): `delete_suspicious_flag_by_message` — reuses the insert route's `message_to_completion_id` CTE identifier model and returns the deleted-row count (0 when nothing matched; no constraint try/except, since a missing flag is not an error).
- **Service** (`completions_service.py`): `remove_suspicious_flags` — thin delegate, returns the count.
- **Controller** (`routes/v3/completions.py`): `delete_suspicious_flags` handler with `status_code=200`, the same `message_id`/`verification_id` 400 guard as the add route, and matching auth (no extra `required_scopes` — mirrors the sibling).
- **Bot** (`api_service.py`): `remove_suspicious_flags` client using `Route("DELETE", "/completions/suspicious")`.

## Behavior

- Identifier model matches the add route exactly (resolve completion by `message_id` **or** `verification_id`).
- Removing a non-existent flag returns **200 with count 0** — consistent with the moderate flow's `unmark_suspicious`, no 500.
- No RabbitMQ event added (the add route publishes none; removal stays symmetric).

## Verification

- `just lint-all`: clean across sdk/api/bot (format + lint + typecheck).
- `pytest test_completions_integration.py -k suspicious`: 6 passed (3 pre-existing + 3 new: happy-path count 1, no-flag count 0, missing-identifier 400).

🤖 Generated with [Claude Code](https://claude.com/claude-code)